### PR TITLE
close of closed channel

### DIFF
--- a/pkg/service/physicalRegistrationService.go
+++ b/pkg/service/physicalRegistrationService.go
@@ -42,7 +42,7 @@ type PhysicalDatabaseRegistrationService struct {
 
 	// mutex is used to synchronize concurrent registrations.
 	mutex       sync.Mutex
-	executor    helper.BackgroundExecutor
+	executor    *helper.BackgroundExecutor
 	loopContext context.Context
 	status      entity.Status
 }
@@ -74,7 +74,7 @@ func NewPhysicalRegistrationService(
 		registrationFixedDelay: registrationFixedDelay,
 		registrationRetryTime:  registrationRetryTime,
 		registrationRetryDelay: registrationRetryDelay,
-		executor:               *helper.NewBackgroundExecutor(),
+		executor:               helper.NewBackgroundExecutor(),
 		administrationService:  administrationService,
 		loopContext:            context,
 		status:                 entity.StatusRunning,


### PR DESCRIPTION

The panic “close of closed channel” happens inside the PhysicalDatabaseRegistrationService during performAdditionalRoles, which is called from registerWithRoles in a goroutine started by StartRegister. may be somewhere in the code that a channel is trying to close more than once.

Even though registerWithRoles itself doesn’t close any channels, may be the panic suggests that deeper in the call stack, . as the service runs background tasks like role registration through the executor, the problem might be related to how channels used by the executor or the role registration process. 

The logs don’t clearly show the executor as the cause, i believe the executor manages a queue channel for submitting and running tasks, if that channel is closed multiple times either directly or indirectly it could cause this panic.


